### PR TITLE
Made getPackageVersions() resilient to package.json's that couldn't be parsed

### DIFF
--- a/.changeset/healthy-emus-deny.md
+++ b/.changeset/healthy-emus-deny.md
@@ -1,0 +1,5 @@
+---
+"update-workspace-root-version": patch
+---
+
+Made getPackageVersions() resilient to package.json's that couldn't be parsed

--- a/src/steps/get-package-versions.ts
+++ b/src/steps/get-package-versions.ts
@@ -31,9 +31,13 @@ export function getPackageVersions(options: Options): string[] {
 
   return packageRoots
     .map((packageRoot) => {
-      const packageJson = readPackageJson({ projectRoot: packageRoot });
+      try {
+        const packageJson = readPackageJson({ projectRoot: packageRoot });
 
-      return packageJson['version'];
+        return packageJson['version'];
+      } catch {
+        return undefined;
+      }
     })
     .filter(allow) as string[];
 }

--- a/tests/steps/get-package-versions/edge-case-file-cannot-be-parsed.test.ts
+++ b/tests/steps/get-package-versions/edge-case-file-cannot-be-parsed.test.ts
@@ -1,0 +1,23 @@
+import { assert, loadFixture, test } from '@codemod-utils/tests';
+
+import { getPackageVersions } from '../../../src/steps/index.js';
+import {
+  codemodOptions,
+  options,
+} from '../../helpers/shared-test-setups/monorepo-highest-version-1.js';
+
+test('steps | get-package-versions > file cannot be parsed', function () {
+  loadFixture(
+    {
+      'package.json': [
+        '<% if (options.codemod.hasTypeScript) { %>{',
+        '  "name": "<%= options.codemod.name %>",',
+        '  "version": "0.0.0"',
+        '}<% } %>',
+      ].join('\n'),
+    },
+    codemodOptions,
+  );
+
+  assert.deepStrictEqual(getPackageVersions(options), []);
+});

--- a/tests/steps/get-package-versions/edge-case-version-is-missing.test.ts
+++ b/tests/steps/get-package-versions/edge-case-version-is-missing.test.ts
@@ -1,0 +1,18 @@
+import { assert, loadFixture, test } from '@codemod-utils/tests';
+
+import { getPackageVersions } from '../../../src/steps/index.js';
+import {
+  codemodOptions,
+  options,
+} from '../../helpers/shared-test-setups/monorepo-highest-version-1.js';
+
+test('steps | get-package-versions > version is missing', function () {
+  loadFixture(
+    {
+      'package.json': '{\n  "name": "workspace-root",\n  "private": true\n}\n',
+    },
+    codemodOptions,
+  );
+
+  assert.deepStrictEqual(getPackageVersions(options), []);
+});


### PR DESCRIPTION
## Background

I encountered a runtime error in [`@codemod-utils`](https://github.com/ijlee2/codemod-utils), because `update-workspace-root-version` tried to read [a blueprint `package.json`](https://github.com/ijlee2/codemod-utils/blob/2.0.9/packages/cli/src/blueprints/package.json). This file also happened to be in the folder `dist-for-testing`, which `update-workspace-root-version` doesn't/can't know about.

