### PR TITLE
Updated script name in README

### DIFF
--- a/.changeset/gentle-hounds-jog.md
+++ b/.changeset/gentle-hounds-jog.md
@@ -1,0 +1,5 @@
+---
+"update-workspace-root-version": patch
+---
+
+Updated README

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Then, run the codemod before you create a tag. For example, after [changesets](h
 /* package.json */
 {
   "scripts": {
-    "release:changelog": "changeset version; update-workspace-root-version",
+    "release:prepare": "changeset version; update-workspace-root-version"
   },
   "devDependencies": {
     "@changesets/cli": "...",


### PR DESCRIPTION
## Background

I changed the name to `release:prepare` in my projects so that it captures the intent of the script (when to use it) better.